### PR TITLE
增加 PMBus 校验逻辑, 增加 ESPHome 样例

### DIFF
--- a/Software/Arduino_CSPS_Lib/KCORES_CSPS.h
+++ b/Software/Arduino_CSPS_Lib/KCORES_CSPS.h
@@ -19,6 +19,7 @@ class CSPS
 public:
   CSPS(byte CSPS_addr);
   CSPS(byte CSPS_addr, byte ROM_addr);
+  CSPS(byte CSPS_addr, byte ROM_addr, bool ENABLE_CHECKSUM);
 
   String getROM(byte addr, byte len);
 
@@ -114,6 +115,7 @@ public:
   };
 
 private:
+  bool _CSPS_READ_CHECKSUM;
   byte _CSPS_addr;
   byte _ROM_addr;
   byte readROM(byte dataAddr);

--- a/Software/Arduino_CSPS_Lib/examples/ESPHome/README.md
+++ b/Software/Arduino_CSPS_Lib/examples/ESPHome/README.md
@@ -27,21 +27,30 @@ sensor:
 
     sensors:
     - name: "Fan Speed"
-      accuracy_decimals: 1
+      accuracy_decimals: 0
+      unit_of_measurement: RPM
     - name: "Temp 1"
       accuracy_decimals: 1
+      unit_of_measurement: °C
     - name: "Temp 2"
       accuracy_decimals: 1
+      unit_of_measurement: °C
     - name: "Power Out"
-      accuracy_decimals: 1
+      accuracy_decimals: 0
+      unit_of_measurement: W
     - name: "Power In"
-      accuracy_decimals: 1
+      accuracy_decimals: 0
+      unit_of_measurement: W
     - name: "Current Out"
       accuracy_decimals: 1
+      unit_of_measurement: A
     - name: "Current In"
       accuracy_decimals: 1
+      unit_of_measurement: A
     - name: "Voltage Out"
       accuracy_decimals: 1
+      unit_of_measurement: V
     - name: "Voltage In"
       accuracy_decimals: 1
+      unit_of_measurement: V
 ```

--- a/Software/Arduino_CSPS_Lib/examples/ESPHome/README.md
+++ b/Software/Arduino_CSPS_Lib/examples/ESPHome/README.md
@@ -1,0 +1,47 @@
+# ESPHome 集成
+
+在 ESPHome 的 yaml 中增加
+
+```yaml
+esphome:
+  # 原先内容
+  includes:
+    - CSPS/main.hpp
+    - CSPS/KCORES_CSPS.h
+    - CSPS/KCORES_CSPS.cpp
+```
+
+创建文件夹 `CSPS` 将 `main.hpp`, `KCORES_CSPS.h` 以及 `KCORES_CSPS.cpp` 丢进去
+
+## 增加传感器
+
+使用自定义传感器获取数据
+
+```yaml
+sensor:
+  - platform: custom
+    lambda: |-
+      auto power = new CSPSPower();
+      App.register_component(power);
+      return {power->fan_speed, power->temp1, power->temp2, power->power_out, power->power_in, power->current_out, power->current_in, power->voltage_out, power->voltage_in};
+
+    sensors:
+    - name: "Fan Speed"
+      accuracy_decimals: 1
+    - name: "Temp 1"
+      accuracy_decimals: 1
+    - name: "Temp 2"
+      accuracy_decimals: 1
+    - name: "Power Out"
+      accuracy_decimals: 1
+    - name: "Power In"
+      accuracy_decimals: 1
+    - name: "Current Out"
+      accuracy_decimals: 1
+    - name: "Current In"
+      accuracy_decimals: 1
+    - name: "Voltage Out"
+      accuracy_decimals: 1
+    - name: "Voltage In"
+      accuracy_decimals: 1
+```

--- a/Software/Arduino_CSPS_Lib/examples/ESPHome/main.cpp
+++ b/Software/Arduino_CSPS_Lib/examples/ESPHome/main.cpp
@@ -1,0 +1,44 @@
+#include "KCORES_CSPS.h"
+#include "esphome.h"
+
+CSPS PowerSupply(0x5F, 0x57, true);
+
+class CSPSPower : public PollingComponent {
+  public:
+    Sensor *fan_speed = new Sensor();
+    Sensor *temp1 = new Sensor();
+    Sensor *temp2 = new Sensor();
+    Sensor *power_in = new Sensor();
+    Sensor *power_out = new Sensor();
+    Sensor *current_out = new Sensor();
+    Sensor *current_in = new Sensor();
+    Sensor *voltage_out = new Sensor();
+    Sensor *voltage_in = new Sensor();
+
+    CSPSPower(): PollingComponent(15000) { }
+
+    void setup() override {
+      Wire.setClock(10000);
+
+      ESP_LOGD("Power Supply", "Spare Part No: %s", PowerSupply.getSPN().c_str());
+      ESP_LOGD("Power Supply", "Manufacture Date: %s", PowerSupply.getMFG().c_str());
+      ESP_LOGD("Power Supply", "Manufacturer: %s", PowerSupply.getMFR().c_str());
+      ESP_LOGD("Power Supply", "Power Name: %s", PowerSupply.getName().c_str());
+      ESP_LOGD("Power Supply", "Option Kit No: %s", PowerSupply.getOKN().c_str());
+      ESP_LOGD("Power Supply", "CT Date Codes: %s", PowerSupply.getCT().c_str());
+    }
+
+    void update() override {
+      // float current_out = PowerSupply.getOutputCurrent() / 256 / 256 / 256;
+
+      fan_speed->publish_state(PowerSupply.getFanRPM());
+      temp1->publish_state(PowerSupply.getTemp1());
+      temp2->publish_state(PowerSupply.getTemp2());
+      power_out->publish_state(PowerSupply.getOutputPower());
+      power_in->publish_state(PowerSupply.getInputPower());
+      current_out->publish_state(PowerSupply.getOutputCurrent());
+      current_in->publish_state(PowerSupply.getInputCurrent());
+      voltage_out->publish_state(PowerSupply.getOutputVoltage());
+      voltage_in->publish_state(PowerSupply.getInputVoltage());
+    }
+};


### PR DESCRIPTION
在 CSPS 从 PMBUS 读数据的时候发现读出来的数据有一点点不太对, 然后搜了一下别的读 PMBUS 是怎么做的然后发现是有个 Checksum [DPS-1200FB](https://github.com/raplin/DPS-1200FB/blob/master/DPS-1200FB.py#L119-L121)

测试了 `441830-001` 是有返回的

加了个选项来启用（好像这玩意还不是全都有的？）